### PR TITLE
[ISSUE] Fix warning about consumables warning in the log

### DIFF
--- a/backend/lib/res/default_config.json
+++ b/backend/lib/res/default_config.json
@@ -54,7 +54,7 @@
             }
         },
         "customizations": {
-            "topicPrefix": "",
+            "topicPrefix": "valetudo",
             "provideMapData": true
         }
     },


### PR DESCRIPTION
## WARNING!
Thins fix needs to be tested. I can not have a test enviroment to test this fix.

## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

This try to fix warning in the log of Valetudo about consumables. Because topic is not set in the Valetudo settings consumables status for any reason is not send to the `valetudo` mqtt topic as other status values.

The warning looks like:

```bash
[2021-10-18T09:26:34.035Z] [WARN] Failed to get consumables: DomainException: Timeout waiting for response from opcode 'DEVICE_MAPID_GET_CONSUMABLES_PARAM_RSP'
    at Timeout.fail [as _onTimeout] (/snapshot/app/node_modules/@agnoc/core/lib/emitters/robot.emitter.js:1181:16)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7) {
  metadata: undefined
}
```

After a fast view I do not think that the error is in @agnoc/core package.
