### PR TITLE
feat(cecotec): add edge cleaning support

### DIFF
--- a/backend/lib/core/capabilities/EdgeCleaningCapability.js
+++ b/backend/lib/core/capabilities/EdgeCleaningCapability.js
@@ -1,0 +1,23 @@
+const Capability = require("./Capability");
+const NotImplementedError = require("../NotImplementedError");
+
+class EdgeCleaningCapability extends Capability {
+    async start() {
+        throw new NotImplementedError();
+    }
+
+    getProperties() {
+        return {
+            wholeHouse: true,
+            segmentSelection: false
+        };
+    }
+
+    getType() {
+        return EdgeCleaningCapability.TYPE;
+    }
+}
+
+EdgeCleaningCapability.TYPE = "EdgeCleaningCapability";
+
+module.exports = EdgeCleaningCapability;

--- a/backend/lib/core/capabilities/index.js
+++ b/backend/lib/core/capabilities/index.js
@@ -5,6 +5,7 @@ module.exports = {
     ConsumableMonitoringCapability: require("./ConsumableMonitoringCapability"),
     CurrentStatisticsCapability: require("./CurrentStatisticsCapability"),
     DoNotDisturbCapability: require("./DoNotDisturbCapability"),
+    EdgeCleaningCapability: require("./EdgeCleaningCapability"),
     FanSpeedControlCapability: require("./FanSpeedControlCapability"),
     GoToLocationCapability: require("./GoToLocationCapability"),
     KeyLockCapability: require("./KeyLockCapability"),

--- a/backend/lib/robots/cecotec/CecotecCongaRobot.js
+++ b/backend/lib/robots/cecotec/CecotecCongaRobot.js
@@ -240,6 +240,12 @@ module.exports = class CecotecCongaRobot extends ValetudoRobot {
             })
         );
 
+        this.registerCapability(
+            new capabilities.CecotecEdgeCleaningCapability({
+                robot: this,
+            })
+        );
+
         this.server.on("error", this.onError.bind(this));
         this.server.on("addRobot", this.onAddRobot.bind(this));
 

--- a/backend/lib/robots/cecotec/capabilities/CecotecEdgeCleaningCapability.js
+++ b/backend/lib/robots/cecotec/capabilities/CecotecEdgeCleaningCapability.js
@@ -1,0 +1,22 @@
+const EdgeCleaningCapability = require("../../../core/capabilities/EdgeCleaningCapability");
+
+module.exports = class CecotecEdgeCleaningCapability extends EdgeCleaningCapability {
+    async start() {
+        if (!this.robot.robot) {
+            throw new Error("There is no robot connected to server");
+        }
+
+        if (typeof this.robot.robot.cleanEdgesDirect !== "function") {
+            throw new Error("Agnoc cleanEdgesDirect() is not available");
+        }
+
+        await this.robot.robot.cleanEdgesDirect();
+    }
+
+    getProperties() {
+        return {
+            wholeHouse: true,
+            segmentSelection: false
+        };
+    }
+};

--- a/backend/lib/robots/cecotec/capabilities/CecotecEdgeCleaningCapability.js
+++ b/backend/lib/robots/cecotec/capabilities/CecotecEdgeCleaningCapability.js
@@ -3,7 +3,7 @@ const EdgeCleaningCapability = require("../../../core/capabilities/EdgeCleaningC
 module.exports = class CecotecEdgeCleaningCapability extends EdgeCleaningCapability {
     async start() {
         if (!this.robot.robot) {
-            throw new Error("There is no robot connected to server");
+            throw new TypeError("There is no robot connected to server");
         }
 
         if (typeof this.robot.robot.cleanEdgesDirect !== "function") {

--- a/backend/lib/robots/cecotec/capabilities/CecotecEdgeCleaningCapability.js
+++ b/backend/lib/robots/cecotec/capabilities/CecotecEdgeCleaningCapability.js
@@ -7,7 +7,7 @@ module.exports = class CecotecEdgeCleaningCapability extends EdgeCleaningCapabil
         }
 
         if (typeof this.robot.robot.cleanEdgesDirect !== "function") {
-            throw new Error("Agnoc cleanEdgesDirect() is not available");
+            throw new TypeError("Agnoc cleanEdgesDirect() is not available");
         }
 
         await this.robot.robot.cleanEdgesDirect();

--- a/backend/lib/robots/cecotec/capabilities/index.js
+++ b/backend/lib/robots/cecotec/capabilities/index.js
@@ -5,6 +5,7 @@ module.exports = {
     CecotecConsumableMonitoringCapability: require("./CecotecConsumableMonitoringCapability"),
     CecotecCurrentStatisticsCapability: require("./CecotecCurrentStatisticsCapability"),
     CecotecDoNotDisturbCapability: require("./CecotecDoNotDisturbCapability"),
+    CecotecEdgeCleaningCapability: require("./CecotecEdgeCleaningCapability"),
     CecotecFanSpeedControlCapability: require("./CecotecFanSpeedControlCapability"),
     CecotecGoToLocationCapability: require("./CecotecGoToLocationCapability"),
     CecotecLocateCapability: require("./CecotecLocateCapability"),

--- a/backend/lib/webserver/CapabilitiesRouter.js
+++ b/backend/lib/webserver/CapabilitiesRouter.js
@@ -57,6 +57,7 @@ const CAPABILITY_TYPE_TO_ROUTER_MAPPING = {
     [capabilities.OperationModeControlCapability.TYPE]: capabilityRouters.PresetSelectionCapabilityRouter,
     [capabilities.ConsumableMonitoringCapability.TYPE]: capabilityRouters.ConsumableMonitoringCapabilityRouter,
     [capabilities.ZoneCleaningCapability.TYPE]: capabilityRouters.ZoneCleaningCapabilityRouter,
+    [capabilities.EdgeCleaningCapability.TYPE]: capabilityRouters.EdgeCleaningCapabilityRouter,
     [capabilities.GoToLocationCapability.TYPE]: capabilityRouters.GoToLocationCapabilityRouter,
     [capabilities.WifiConfigurationCapability.TYPE]: capabilityRouters.WifiConfigurationCapabilityRouter,
     [capabilities.MapSnapshotCapability.TYPE]: capabilityRouters.MapSnapshotCapabilityRouter,

--- a/backend/lib/webserver/capabilityRouters/EdgeCleaningCapabilityRouter.js
+++ b/backend/lib/webserver/capabilityRouters/EdgeCleaningCapabilityRouter.js
@@ -1,0 +1,28 @@
+const CapabilityRouter = require("./CapabilityRouter");
+
+class EdgeCleaningCapabilityRouter extends CapabilityRouter {
+    initRoutes() {
+        this.router.put("/", this.validator, async (req, res) => {
+            const body = req.body || {};
+            const action = body.action;
+            const rawSegmentIds = body.segment_ids || body.segmentIds;
+
+            if (Array.isArray(rawSegmentIds) && rawSegmentIds.length > 0) {
+                return res.status(400).json("segment_ids are not supported by edge cleaning");
+            }
+
+            if (action === "clean" || action === "start") {
+                try {
+                    await this.capability.start();
+                    res.sendStatus(200);
+                } catch (e) {
+                    this.sendErrorResponse(req, res, e);
+                }
+            } else {
+                res.sendStatus(400);
+            }
+        });
+    }
+}
+
+module.exports = EdgeCleaningCapabilityRouter;

--- a/backend/lib/webserver/capabilityRouters/doc/EdgeCleaningCapabilityRouter.openapi.json
+++ b/backend/lib/webserver/capabilityRouters/doc/EdgeCleaningCapabilityRouter.openapi.json
@@ -1,0 +1,37 @@
+{
+  "paths": {
+    "/api/v2/robot/capabilities/EdgeCleaningCapability": {
+      "put": {
+        "tags": ["Robot Capabilities"],
+        "summary": "Start edge cleaning",
+        "description": "Starts whole-house edge/follow-wall cleaning. Segment selection is not supported by this capability.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["action"],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": ["clean", "start"],
+                    "default": "clean"
+                  }
+                }
+              },
+              "example": {
+                "action": "clean"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {"description": "OK"},
+          "400": {"description": "Bad request"},
+          "500": {"description": "Robot or firmware error"}
+        }
+      }
+    }
+  }
+}

--- a/backend/lib/webserver/capabilityRouters/index.js
+++ b/backend/lib/webserver/capabilityRouters/index.js
@@ -3,6 +3,7 @@ module.exports = {
     CombinedVirtualRestrictionsCapabilityRouter: require("./CombinedVirtualRestrictionsCapabilityRouter"),
     ConsumableMonitoringCapabilityRouter: require("./ConsumableMonitoringCapabilityRouter"),
     DoNotDisturbCapabilityRouter: require("./DoNotDisturbCapabilityRouter"),
+    EdgeCleaningCapabilityRouter: require("./EdgeCleaningCapabilityRouter"),
     GoToLocationCapabilityRouter: require("./GoToLocationCapabilityRouter"),
     LocateCapabilityRouter: require("./LocateCapabilityRouter"),
     ManualControlCapabilityRouter: require("./ManualControlCapabilityRouter"),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -34,6 +34,7 @@ export enum Capability {
     WifiConfiguration = "WifiConfigurationCapability",
     WifiScan = "WifiScanCapability",
     ZoneCleaning = "ZoneCleaningCapability",
+    EdgeCleaning = "EdgeCleaningCapability",
     Quirks = "QuirksCapability",
 }
 

--- a/frontend/src/map/LiveMap.tsx
+++ b/frontend/src/map/LiveMap.tsx
@@ -5,6 +5,7 @@ import {ActionsContainer} from "./Styled";
 import SegmentActions from "./actions/live_map_actions/SegmentActions";
 import SegmentLabelMapStructure from "./structures/map_structures/SegmentLabelMapStructure";
 import ZoneActions from "./actions/live_map_actions/ZoneActions";
+import EdgeActions from "./actions/live_map_actions/EdgeActions";
 import ZoneClientStructure from "./structures/client_structures/ZoneClientStructure";
 import GoToActions from "./actions/live_map_actions/GoToActions";
 import {TapTouchHandlerEvent} from "./utils/touch_handling/events/TapTouchHandlerEvent";
@@ -12,13 +13,14 @@ import React from "react";
 import {LiveMapModeSwitcher} from "./LiveMapModeSwitcher";
 
 
-export type LiveMapMode = "segments" | "zones" | "goto" | "none";
+export type LiveMapMode = "segments" | "zones" | "edges" | "goto" | "none";
 const LIVE_MAP_MODE_LOCAL_STORAGE_KEY = "live-map-mode";
 
 interface LiveMapProps extends MapProps {
     supportedCapabilities: {
         [Capability.MapSegmentation]: boolean,
         [Capability.ZoneCleaning]: boolean,
+        [Capability.EdgeCleaning]: boolean,
         [Capability.GoToLocation]: boolean
     }
 }
@@ -42,6 +44,9 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
         }
         if (props.supportedCapabilities[Capability.ZoneCleaning]) {
             this.supportedModes.push("zones");
+        }
+        if (props.supportedCapabilities[Capability.EdgeCleaning]) {
+            this.supportedModes.push("edges");
         }
         if (props.supportedCapabilities[Capability.GoToLocation]) {
             this.supportedModes.push("goto");
@@ -270,6 +275,11 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
                                 this.draw();
                             }}
                         />
+                    }
+                    {
+                        this.state.mode === "edges" &&
+
+                        <EdgeActions />
                     }
                     {
                         this.state.mode === "goto" &&

--- a/frontend/src/map/LiveMapModeSwitcher.tsx
+++ b/frontend/src/map/LiveMapModeSwitcher.tsx
@@ -44,9 +44,22 @@ const StyledSpeedDial = styled(SpeedDial)(({theme}) => {
     };
 });
 
+
+const EdgeModeIcon = (): React.ReactElement => {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 5V19" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeDasharray="2 3"/>
+            <path d="M6 5H18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeDasharray="2 3"/>
+            <path d="M18 5V19" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" opacity="0.55"/>
+            <path d="M10 19H18" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" opacity="0.55"/>
+        </svg>
+    );
+};
+
 const modeToIcon: Record<LiveMapMode, React.ReactElement> = {
     "segments": <SegmentModeIcon/>,
     "zones": <ZoneModeIcon/>,
+    "edges": <EdgeModeIcon/>,
     "goto": <GoToModeIcon/>,
     "none": <NoneModeIcon/>
 };
@@ -54,6 +67,7 @@ const modeToIcon: Record<LiveMapMode, React.ReactElement> = {
 const modeToLabel: Record<LiveMapMode, string> = {
     "segments": "Segments",
     "zones": "Zones",
+    "edges": "Edge",
     "goto": "Go To",
     "none": "None"
 };

--- a/frontend/src/map/actions/live_map_actions/EdgeActions.tsx
+++ b/frontend/src/map/actions/live_map_actions/EdgeActions.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import {Box, CircularProgress, Container, Grid, Typography} from "@mui/material";
+import {ActionButton} from "../../Styled";
+import IntegrationHelpDialog from "../../../components/IntegrationHelpDialog";
+import {useLongPress} from "use-long-press";
+import {useRobotStatusQuery} from "../../../api";
+import {Polyline as EdgeIcon} from "@mui/icons-material";
+
+const EDGE_CLEANING_ENDPOINT = "/api/v2/robot/capabilities/EdgeCleaningCapability";
+const EDGE_CLEANING_PAYLOAD = {
+    action: "clean"
+};
+
+const EdgeActions = (): React.ReactElement => {
+    const [edgeCleanIsExecuting, setEdgeCleanIsExecuting] = React.useState(false);
+    const [edgeCleanError, setEdgeCleanError] = React.useState<string | undefined>(undefined);
+    const [integrationHelpDialogOpen, setIntegrationHelpDialogOpen] = React.useState(false);
+
+    const {data: status} = useRobotStatusQuery((state) => {
+        return state.value;
+    });
+
+    const canClean = status === "idle" || status === "docked" || status === "paused" || status === "returning" || status === "error";
+
+    const handleClick = React.useCallback(() => {
+        if (!canClean || edgeCleanIsExecuting) {
+            return;
+        }
+
+        setEdgeCleanError(undefined);
+        setEdgeCleanIsExecuting(true);
+
+        fetch(EDGE_CLEANING_ENDPOINT, {
+            method: "PUT",
+            headers: {
+                accept: "*/*",
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(EDGE_CLEANING_PAYLOAD)
+        }).then(async response => {
+            if (!response.ok) {
+                throw new Error(await response.text());
+            }
+        }).catch(err => {
+            const message = err instanceof Error ? err.message : String(err);
+
+            setEdgeCleanError(message);
+        }).finally(() => {
+            setEdgeCleanIsExecuting(false);
+        });
+    }, [canClean, edgeCleanIsExecuting]);
+
+    const handleLongClick = React.useCallback(() => {
+        setIntegrationHelpDialogOpen(true);
+    }, []);
+
+    const setupClickHandlers = useLongPress(
+        handleLongClick,
+        {
+            onCancel: () => {
+                handleClick();
+            },
+            threshold: 500,
+            captureEvent: true,
+            cancelOnMovement: true,
+        }
+    );
+
+    return (
+        <>
+            <Grid container spacing={1} direction="row-reverse" flexWrap="wrap-reverse">
+                <Grid item>
+                    <ActionButton
+                        disabled={edgeCleanIsExecuting || !canClean}
+                        color="inherit"
+                        size="medium"
+                        variant="extended"
+                        {...setupClickHandlers()}
+                    >
+                        <EdgeIcon style={{marginRight: "0.25rem", marginLeft: "-0.25rem"}}/>
+                        Edge
+                        {edgeCleanIsExecuting && (
+                            <CircularProgress
+                                color="inherit"
+                                size={18}
+                                style={{marginLeft: 10}}
+                            />
+                        )}
+                    </ActionButton>
+                </Grid>
+                {
+                    !canClean &&
+                    <Grid item>
+                        <Typography variant="caption" color="textSecondary">
+                            Cannot start edge cleaning while the robot is busy
+                        </Typography>
+                    </Grid>
+                }
+                {
+                    edgeCleanError !== undefined &&
+                    <Grid item>
+                        <Typography variant="caption" color="error">
+                            {edgeCleanError}
+                        </Typography>
+                    </Grid>
+                }
+            </Grid>
+            <Box m={1}/>
+            <Container>
+                <Typography variant="caption" color="textSecondary">
+                    Starts edge/follow-wall cleaning for the whole house.
+                </Typography>
+            </Container>
+            <IntegrationHelpDialog
+                dialogOpen={integrationHelpDialogOpen}
+                setDialogOpen={(open: boolean) => {
+                    setIntegrationHelpDialogOpen(open);
+                }}
+                coordinatesWarning={false}
+                helperText={"To start edge cleaning via REST, use this payload on /api/v2/robot/capabilities/EdgeCleaningCapability."}
+                payload={JSON.stringify(EDGE_CLEANING_PAYLOAD, null, 2)}
+            />
+        </>
+    );
+};
+
+export default EdgeActions;


### PR DESCRIPTION
Adds Cecotec/Conga edge cleaning support.

Changes:
- Adds a generic EdgeCleaningCapability.
- Adds CecotecEdgeCleaningCapability using Agnoc cleanEdgesDirect().
- Adds an EdgeCleaningCapability API route and OpenAPI documentation.
- Adds an Edge mode/action in the live map UI.
- Prevents segment selection for edge cleaning.

This depends on Agnoc support for cleanEdgesDirect() / DEVICE_BORDER_CLEAN_REQ.