### PR TITLE
feat(cecotec): support zone cleaning iterations

### DIFF
--- a/backend/lib/robots/cecotec/capabilities/CecotecZoneCleaningCapability.js
+++ b/backend/lib/robots/cecotec/capabilities/CecotecZoneCleaningCapability.js
@@ -41,7 +41,16 @@ module.exports = class CecotecZoneCleaningCapability extends ZoneCleaningCapabil
                 ]);
         });
 
-        await this.robot.robot.cleanAreas(areas);
+        const iterations = Math.max(1, Math.min(2, Number(options.iterations) || 1));
+        const repeatedAreas = [];
+
+        areas.forEach(area => {
+            for (let i = 0; i < iterations; i++) {
+                repeatedAreas.push(area);
+            }
+        });
+
+        await this.robot.robot.cleanAreas(repeatedAreas);
     }
 
     /**


### PR DESCRIPTION
Adds Cecotec/Conga zone cleaning iteration support.

Changes:
- Repeats the cleanAreas payload according to the requested iteration count.
- Keeps the existing Cecotec zone coordinate conversion unchanged.
- Does not change segment cleaning, room ordering, or repeatClean behavior.

This allows iterations=2 for zone cleaning by sending each selected zone twice in the area cleaning request.