### PR TITLE
feat(cecotec): support segment cleaning iterations

### DIFF
--- a/backend/lib/robots/cecotec/capabilities/CecotecMapSegmentationCapability.js
+++ b/backend/lib/robots/cecotec/capabilities/CecotecMapSegmentationCapability.js
@@ -9,9 +9,10 @@ class CecotecMapSegmentationCapability extends MapSegmentationCapability {
      *
      *
      * @param {Array<import("../../../entities/core/ValetudoMapSegment")>} segments
+     * @param {{iterations?: number}} [options]
      * @returns {Promise<void>}
      */
-    async executeSegmentAction(segments) {
+    async executeSegmentAction(segments, options = {}) {
         if (!this.robot.robot) {
             throw new Error("There is no robot connected to server");
         }
@@ -29,8 +30,52 @@ class CecotecMapSegmentationCapability extends MapSegmentationCapability {
             return segmentIds.includes(room.id.toString());
         });
 
+        const iterations = Math.max(1, Math.min(2, Number(options.iterations) || 1));
+
+        if (iterations > 1) {
+            await this._setNativeRepeatClean(true);
+        }
+
         await this.robot.robot.cleanRooms(rooms);
     }
+    /**
+     * @param {boolean} enabled
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _setNativeRepeatClean(enabled) {
+        const agnocRobot = this.robot.robot;
+
+        if (!agnocRobot || typeof agnocRobot.sendRecv !== "function") {
+            throw new Error("Segment iterations require native repeatClean support");
+        }
+
+        await agnocRobot.sendRecv(
+            "USER_SET_DEVICE_CLEANPREFERENCE_REQ",
+            "USER_SET_DEVICE_CLEANPREFERENCE_RSP",
+            {
+                repeatClean: Boolean(enabled)
+            }
+        );
+
+        if (typeof agnocRobot.emit === "function") {
+            agnocRobot.emit("updateDevice");
+        }
+    }
+
+    /**
+     * @returns {import("../../../core/capabilities/MapSegmentationCapability").MapSegmentationCapabilityProperties}
+     */
+    getProperties() {
+        return {
+            iterationCount: {
+                min: 1,
+                max: 2
+            },
+            customOrderSupport: false
+        };
+    }
+
 }
 
 module.exports = CecotecMapSegmentationCapability;


### PR DESCRIPTION
Adds Cecotec/Conga segment cleaning iteration support.

Changes:
- Passes the requested iteration count to Cecotec segment cleaning.
- Enables the robot native repeatClean preference when iterations > 1.
- Keeps the existing cleanRooms behavior unchanged.
- Does not add custom room ordering support.
- Does not duplicate room payload entries.

This allows iterations=2 for segment cleaning using the robot native repeat-clean behavior.