### PR TITLE
feat(ui): add zone order and measurement labels

### DIFF
--- a/backend/lib/doc/Configuration.openapi.json
+++ b/backend/lib/doc/Configuration.openapi.json
@@ -94,6 +94,9 @@
           "_version": {
             "type": "string",
             "description": "Used for migration purposes"
+          },
+          "congatudo": {
+            "$ref": "#/components/schemas/CongatudoConfiguration"
           }
         }
       },
@@ -490,6 +493,33 @@
                 }
               }
             }
+          }
+        }
+      },
+      "CongatudoZoneMeasurementConfiguration": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "cmPerMapUnit": {
+            "type": "number",
+            "nullable": true,
+            "minimum": 0.000001,
+            "description": "Optional UI-only centimeters-per-map-unit override for manual zone measurement labels. If null or unset, the frontend uses the map pixel size as before."
+          },
+          "segmentAreaMultiplier": {
+            "type": "number",
+            "minimum": 0.000001,
+            "default": 1,
+            "description": "Optional UI-only multiplier for displayed room/segment area labels. It does not affect maps or cleaning payloads."
+          }
+        }
+      },
+      "CongatudoConfiguration": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "zoneMeasurement": {
+            "$ref": "#/components/schemas/CongatudoZoneMeasurementConfiguration"
           }
         }
       }

--- a/backend/lib/res/default_config.json
+++ b/backend/lib/res/default_config.json
@@ -88,5 +88,11 @@
         "customizations": {
             "friendlyName": ""
         }
+    },
+    "congatudo": {
+        "zoneMeasurement": {
+            "cmPerMapUnit": null,
+            "segmentAreaMultiplier": 1
+        }
     }
 }

--- a/backend/lib/webserver/ValetudoRouter.js
+++ b/backend/lib/webserver/ValetudoRouter.js
@@ -173,6 +173,20 @@ class ValetudoRouter {
             }
         });
 
+        this.router.get("/config/congatudo", (req, res) => {
+            const congatudoConfig = this.config.get("congatudo") || {};
+            const zoneMeasurementConfig = congatudoConfig.zoneMeasurement || {};
+            const cmPerMapUnit = Number(zoneMeasurementConfig.cmPerMapUnit);
+            const segmentAreaMultiplier = Number(zoneMeasurementConfig.segmentAreaMultiplier);
+
+            res.json({
+                zoneMeasurement: {
+                    cmPerMapUnit: Number.isFinite(cmPerMapUnit) && cmPerMapUnit > 0 ? cmPerMapUnit : null,
+                    segmentAreaMultiplier: Number.isFinite(segmentAreaMultiplier) && segmentAreaMultiplier > 0 ? segmentAreaMultiplier : 1
+                }
+            });
+        });
+
         this.router.get("/config/customizations", (req, res) => {
             const valetudoConfig = this.config.get("valetudo");
 

--- a/frontend/src/map/LiveMap.tsx
+++ b/frontend/src/map/LiveMap.tsx
@@ -17,6 +17,29 @@ export type LiveMapZoneOrderMode = "manual" | "auto";
 const LIVE_MAP_MODE_LOCAL_STORAGE_KEY = "live-map-mode";
 const LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY = "live-map-zone-order-mode";
 
+const getLiveMapLocalStorageItem = (key: string): string | null => {
+    try {
+        return globalThis.localStorage.getItem(key);
+    } catch (error) {
+        if (!(error instanceof DOMException) && !(error instanceof TypeError)) {
+            throw error;
+        }
+
+        return null;
+    }
+};
+
+const setLiveMapLocalStorageItem = (key: string, value: string): void => {
+    try {
+        globalThis.localStorage.setItem(key, value);
+    } catch (error) {
+        if (!(error instanceof DOMException) && !(error instanceof TypeError)) {
+            throw error;
+        }
+    }
+};
+
+
 const getLiveMapZoneCenter = (zone: ZoneClientStructure): {x: number, y: number} => {
     return {
         x: (zone.x0 + zone.x1) / 2,
@@ -110,19 +133,15 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
 
         let modeIdxToUse = 0;
         let zoneOrderModeToUse: LiveMapZoneOrderMode = "manual";
-        try {
-            const previousMode = globalThis.localStorage.getItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY);
-            const previousZoneOrderMode = globalThis.localStorage.getItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY);
+        const previousMode = getLiveMapLocalStorageItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY);
+        const previousZoneOrderMode = getLiveMapLocalStorageItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY);
 
-            modeIdxToUse = Math.max(
-                this.supportedModes.findIndex(e => e === previousMode),
-                0 //default to the first if not defined or not supported
-            );
+        modeIdxToUse = Math.max(
+            this.supportedModes.findIndex(e => e === previousMode),
+            0 //default to the first if not defined or not supported
+        );
 
-            zoneOrderModeToUse = previousZoneOrderMode === "auto" ? "auto" : "manual";
-        } catch (e) {
-            /* users with non-working local storage will have to live with the defaults */
-        }
+        zoneOrderModeToUse = previousZoneOrderMode === "auto" ? "auto" : "manual";
 
         this.state = {
             mode: this.supportedModes[modeIdxToUse] ?? "none",
@@ -277,11 +296,7 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
                                 mode: newMode
                             });
 
-                            try {
-                                globalThis.localStorage.setItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY, newMode);
-                            } catch (e) {
-                                /* intentional */
-                            }
+                            setLiveMapLocalStorageItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY, newMode);
                         }}
                     />
                 }
@@ -322,7 +337,7 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
                                     this.redrawLayers();
                                 });
 
-                                globalThis.localStorage.setItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY, newZoneOrderMode);
+                                setLiveMapLocalStorageItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY, newZoneOrderMode);
                             }}
                             convertPixelCoordinatesToCMSpace={(coordinates => {
                                 return this.structureManager.convertPixelCoordinatesToCMSpace(coordinates);

--- a/frontend/src/map/LiveMap.tsx
+++ b/frontend/src/map/LiveMap.tsx
@@ -111,8 +111,8 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
         let modeIdxToUse = 0;
         let zoneOrderModeToUse: LiveMapZoneOrderMode = "manual";
         try {
-            const previousMode = window.localStorage.getItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY);
-            const previousZoneOrderMode = window.localStorage.getItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY);
+            const previousMode = globalThis.localStorage.getItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY);
+            const previousZoneOrderMode = globalThis.localStorage.getItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY);
 
             modeIdxToUse = Math.max(
                 this.supportedModes.findIndex(e => e === previousMode),
@@ -278,7 +278,7 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
                             });
 
                             try {
-                                window.localStorage.setItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY, newMode);
+                                globalThis.localStorage.setItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY, newMode);
                             } catch (e) {
                                 /* intentional */
                             }
@@ -322,11 +322,7 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
                                     this.redrawLayers();
                                 });
 
-                                try {
-                                    window.localStorage.setItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY, newZoneOrderMode);
-                                } catch (e) {
-                                    /* intentional */
-                                }
+                                globalThis.localStorage.setItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY, newZoneOrderMode);
                             }}
                             convertPixelCoordinatesToCMSpace={(coordinates => {
                                 return this.structureManager.convertPixelCoordinatesToCMSpace(coordinates);

--- a/frontend/src/map/LiveMap.tsx
+++ b/frontend/src/map/LiveMap.tsx
@@ -13,7 +13,67 @@ import {LiveMapModeSwitcher} from "./LiveMapModeSwitcher";
 
 
 export type LiveMapMode = "segments" | "zones" | "goto" | "none";
+export type LiveMapZoneOrderMode = "manual" | "auto";
 const LIVE_MAP_MODE_LOCAL_STORAGE_KEY = "live-map-mode";
+const LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY = "live-map-zone-order-mode";
+
+const getLiveMapZoneCenter = (zone: ZoneClientStructure): {x: number, y: number} => {
+    return {
+        x: (zone.x0 + zone.x1) / 2,
+        y: (zone.y0 + zone.y1) / 2
+    };
+};
+
+const getLiveMapSquaredDistance = (a: {x: number, y: number}, b: {x: number, y: number}): number => {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+
+    return dx * dx + dy * dy;
+};
+
+const getAutomaticLiveMapZoneOrder = (zones: ZoneClientStructure[]): ZoneClientStructure[] => {
+    if (zones.length <= 2) {
+        return zones;
+    }
+
+    const remaining = [...zones];
+
+    remaining.sort((a, b) => {
+        const ca = getLiveMapZoneCenter(a);
+        const cb = getLiveMapZoneCenter(b);
+
+        return (ca.x + ca.y) - (cb.x + cb.y);
+    });
+
+    const ordered: ZoneClientStructure[] = [];
+    let current = remaining.shift();
+
+    while (current !== undefined) {
+        ordered.push(current);
+
+        if (remaining.length === 0) {
+            break;
+        }
+
+        const currentCenter = getLiveMapZoneCenter(current);
+        let bestIndex = 0;
+        let bestDistance = getLiveMapSquaredDistance(currentCenter, getLiveMapZoneCenter(remaining[0]));
+
+        for (let i = 1; i < remaining.length; i++) {
+            const distance = getLiveMapSquaredDistance(currentCenter, getLiveMapZoneCenter(remaining[i]));
+
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                bestIndex = i;
+            }
+        }
+
+        current = remaining.splice(bestIndex, 1)[0];
+    }
+
+    return ordered;
+};
+
 
 interface LiveMapProps extends MapProps {
     supportedCapabilities: {
@@ -25,6 +85,7 @@ interface LiveMapProps extends MapProps {
 
 interface LiveMapState extends MapState {
     mode: LiveMapMode,
+    zoneOrderMode: LiveMapZoneOrderMode,
     zones: Array<ZoneClientStructure>,
     goToTarget: GoToTargetClientStructure | undefined
 }
@@ -48,19 +109,24 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
         }
 
         let modeIdxToUse = 0;
+        let zoneOrderModeToUse: LiveMapZoneOrderMode = "manual";
         try {
             const previousMode = window.localStorage.getItem(LIVE_MAP_MODE_LOCAL_STORAGE_KEY);
+            const previousZoneOrderMode = window.localStorage.getItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY);
 
             modeIdxToUse = Math.max(
                 this.supportedModes.findIndex(e => e === previousMode),
                 0 //default to the first if not defined or not supported
             );
+
+            zoneOrderModeToUse = previousZoneOrderMode === "auto" ? "auto" : "manual";
         } catch (e) {
             /* users with non-working local storage will have to live with the defaults */
         }
 
         this.state = {
             mode: this.supportedModes[modeIdxToUse] ?? "none",
+            zoneOrderMode: zoneOrderModeToUse,
             selectedSegmentIds: [],
             selectedZoneIds: [],
             zones: [],
@@ -71,10 +137,22 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
     protected updateState() : void {
         super.updateState();
 
+        const zones = this.structureManager.getClientStructures().filter(s => {
+            return s.type === ZoneClientStructure.TYPE;
+        }) as Array<ZoneClientStructure>;
+
+        const zonesForLabels = this.state.zoneOrderMode === "auto" ? getAutomaticLiveMapZoneOrder(zones) : zones;
+
+        zones.forEach(zone => {
+            zone.orderLabel = undefined;
+        });
+
+        zonesForLabels.forEach((zone, idx) => {
+            zone.orderLabel = `${idx + 1}`;
+        });
+
         this.setState({
-            zones: this.structureManager.getClientStructures().filter(s => {
-                return s.type === ZoneClientStructure.TYPE;
-            }) as Array<ZoneClientStructure>,
+            zones: zones,
             goToTarget: this.structureManager.getClientStructures().find(s => {
                 return s.type === GoToTargetClientStructure.TYPE;
             }) as GoToTargetClientStructure | undefined
@@ -233,6 +311,23 @@ class LiveMap extends Map<LiveMapProps, LiveMapState> {
 
                         <ZoneActions
                             zones={this.state.zones}
+                            zoneOrderMode={this.state.zoneOrderMode}
+                            onZoneOrderModeToggle={() => {
+                                const newZoneOrderMode: LiveMapZoneOrderMode = this.state.zoneOrderMode === "manual" ? "auto" : "manual";
+
+                                this.setState({
+                                    zoneOrderMode: newZoneOrderMode
+                                }, () => {
+                                    this.updateState();
+                                    this.redrawLayers();
+                                });
+
+                                try {
+                                    window.localStorage.setItem(LIVE_MAP_ZONE_ORDER_MODE_LOCAL_STORAGE_KEY, newZoneOrderMode);
+                                } catch (e) {
+                                    /* intentional */
+                                }
+                            }}
                             convertPixelCoordinatesToCMSpace={(coordinates => {
                                 return this.structureManager.convertPixelCoordinatesToCMSpace(coordinates);
                             })}

--- a/frontend/src/map/MapMeasurementConfig.ts
+++ b/frontend/src/map/MapMeasurementConfig.ts
@@ -1,0 +1,57 @@
+export type MapMeasurementConfig = {
+    cmPerMapUnit: number | null,
+    segmentAreaMultiplier: number
+};
+
+const DEFAULT_MAP_MEASUREMENT_CONFIG: MapMeasurementConfig = {
+    cmPerMapUnit: null,
+    segmentAreaMultiplier: 1
+};
+
+let config: MapMeasurementConfig = DEFAULT_MAP_MEASUREMENT_CONFIG;
+let loading = false;
+let loaded = false;
+
+function normalizePositiveNumber(value: unknown): number | undefined {
+    const numberValue = Number(value);
+
+    return Number.isFinite(numberValue) && numberValue > 0 ? numberValue : undefined;
+}
+
+function loadMapMeasurementConfig(): void {
+    if (loading || loaded || typeof fetch !== "function") {
+        return;
+    }
+
+    loading = true;
+
+    fetch("./api/v2/valetudo/config/congatudo")
+        .then(response => response.ok ? response.json() : undefined)
+        .then(responseConfig => {
+            const zoneMeasurement = responseConfig?.zoneMeasurement ?? {};
+            const cmPerMapUnit = normalizePositiveNumber(zoneMeasurement.cmPerMapUnit);
+            const segmentAreaMultiplier = normalizePositiveNumber(zoneMeasurement.segmentAreaMultiplier);
+
+            config = {
+                cmPerMapUnit: cmPerMapUnit ?? null,
+                segmentAreaMultiplier: segmentAreaMultiplier ?? DEFAULT_MAP_MEASUREMENT_CONFIG.segmentAreaMultiplier
+            };
+        })
+        .catch(() => undefined)
+        .then(() => {
+            loaded = true;
+            loading = false;
+        });
+}
+
+export function getEffectiveCmPerMapUnit(pixelSize: number): number {
+    loadMapMeasurementConfig();
+
+    return config.cmPerMapUnit ?? pixelSize;
+}
+
+export function getSegmentAreaMultiplier(): number {
+    loadMapMeasurementConfig();
+
+    return config.segmentAreaMultiplier;
+}

--- a/frontend/src/map/actions/edit_map_actions/ZoneActions.tsx
+++ b/frontend/src/map/actions/edit_map_actions/ZoneActions.tsx
@@ -126,10 +126,10 @@ const ZoneActions = (
     );
 
     const handleIterationToggle = React.useCallback(() => {
-        if (zoneProperties) {
+        if (zoneProperties && didSelectZones && canClean && !cleanTemporaryZonesIsExecuting) {
             setIterationCount(iterationCount % zoneProperties.iterationCount.max + 1);
         }
-    }, [iterationCount, setIterationCount, zoneProperties]);
+    }, [iterationCount, setIterationCount, zoneProperties, didSelectZones, canClean, cleanTemporaryZonesIsExecuting]);
 
     if (zonePropertiesLoadError) {
         return (
@@ -191,6 +191,7 @@ const ZoneActions = (
                     zoneProperties.iterationCount.max > 1 &&
                     <Grid item>
                         <ActionButton
+                            disabled={!didSelectZones || cleanTemporaryZonesIsExecuting || !canClean}
                             color="inherit"
                             size="medium"
                             variant="extended"
@@ -206,7 +207,7 @@ const ZoneActions = (
                 }
                 <Grid item>
                     <ActionButton
-                        disabled={zones.length === zoneProperties.zoneCount.max || cleanTemporaryZonesIsExecuting}
+                        disabled={zones.length === zoneProperties.zoneCount.max || cleanTemporaryZonesIsExecuting || !canClean}
                         color="inherit"
                         size="medium"
                         variant="extended"

--- a/frontend/src/map/actions/live_map_actions/ZoneActions.tsx
+++ b/frontend/src/map/actions/live_map_actions/ZoneActions.tsx
@@ -9,6 +9,7 @@ import {Box, Button, CircularProgress, Container, Grid, Typography} from "@mui/m
 import { useLongPress } from "use-long-press";
 import {ActionButton} from "../../Styled";
 import ZoneClientStructure from "../../structures/client_structures/ZoneClientStructure";
+import type {LiveMapZoneOrderMode} from "../../LiveMap";
 import IntegrationHelpDialog from "../../../components/IntegrationHelpDialog";
 import {PointCoordinates} from "../../utils/types";
 import {IterationsIcon} from "../../../assets/icon_components/IterationsIcon";
@@ -18,8 +19,69 @@ import {
     Add as AddIcon
 } from "@mui/icons-material";
 
+
+const getZoneCenter = (zone: ZoneClientStructure): PointCoordinates => {
+    return {
+        x: (zone.x0 + zone.x1) / 2,
+        y: (zone.y0 + zone.y1) / 2
+    };
+};
+
+const getSquaredDistance = (a: PointCoordinates, b: PointCoordinates): number => {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+
+    return dx * dx + dy * dy;
+};
+
+const getAutomaticZoneOrder = (zones: ZoneClientStructure[]): ZoneClientStructure[] => {
+    if (zones.length <= 2) {
+        return zones;
+    }
+
+    const remaining = [...zones];
+
+    remaining.sort((a, b) => {
+        const ca = getZoneCenter(a);
+        const cb = getZoneCenter(b);
+
+        return (ca.x + ca.y) - (cb.x + cb.y);
+    });
+
+    const ordered: ZoneClientStructure[] = [];
+    let current = remaining.shift();
+
+    while (current !== undefined) {
+        ordered.push(current);
+
+        if (remaining.length === 0) {
+            break;
+        }
+
+        const currentCenter = getZoneCenter(current);
+        let bestIndex = 0;
+        let bestDistance = getSquaredDistance(currentCenter, getZoneCenter(remaining[0]));
+
+        for (let i = 1; i < remaining.length; i++) {
+            const distance = getSquaredDistance(currentCenter, getZoneCenter(remaining[i]));
+
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                bestIndex = i;
+            }
+        }
+
+        current = remaining.splice(bestIndex, 1)[0];
+    }
+
+    return ordered;
+};
+
 interface ZoneActionsProperties {
     zones: ZoneClientStructure[];
+    zoneOrderMode: LiveMapZoneOrderMode;
+
+    onZoneOrderModeToggle(): void;
 
     convertPixelCoordinatesToCMSpace(coordinates: PointCoordinates) : PointCoordinates
 
@@ -31,7 +93,7 @@ interface ZoneActionsProperties {
 const ZoneActions = (
     props: ZoneActionsProperties
 ): React.ReactElement => {
-    const { zones, convertPixelCoordinatesToCMSpace, onClear, onAdd } = props;
+    const { zones, zoneOrderMode, onZoneOrderModeToggle, convertPixelCoordinatesToCMSpace, onClear, onAdd } = props;
     const [iterationCount, setIterationCount] = React.useState(1);
     const [integrationHelpDialogOpen, setIntegrationHelpDialogOpen] = React.useState(false);
     const [integrationHelpDialogPayload, setIntegrationHelpDialogPayload] = React.useState("");
@@ -56,7 +118,9 @@ const ZoneActions = (
     const didSelectZones = zones.length > 0;
 
     const zonesForAPI = React.useMemo(() => {
-        return zones.map((zone) => {
+        const zonesForCleaning = zoneOrderMode === "auto" ? getAutomaticZoneOrder(zones) : zones;
+
+        return zonesForCleaning.map((zone) => {
             return {
                 points: {
                     pA: convertPixelCoordinatesToCMSpace({
@@ -78,7 +142,7 @@ const ZoneActions = (
                 }
             };
         });
-    }, [zones, convertPixelCoordinatesToCMSpace]);
+    }, [zones, zoneOrderMode, convertPixelCoordinatesToCMSpace]);
 
     const handleClick = React.useCallback(() => {
         if (!didSelectZones || !canClean) {
@@ -114,10 +178,10 @@ const ZoneActions = (
     );
 
     const handleIterationToggle = React.useCallback(() => {
-        if (zoneProperties) {
+        if (zoneProperties && didSelectZones && canClean && !cleanTemporaryZonesIsExecuting) {
             setIterationCount(iterationCount % zoneProperties.iterationCount.max + 1);
         }
-    }, [iterationCount, setIterationCount, zoneProperties]);
+    }, [iterationCount, setIterationCount, zoneProperties, didSelectZones, canClean, cleanTemporaryZonesIsExecuting]);
 
     if (zonePropertiesLoadError) {
         return (
@@ -180,6 +244,7 @@ const ZoneActions = (
                     zoneProperties.iterationCount.max > 1 &&
                     <Grid item>
                         <ActionButton
+                            disabled={!didSelectZones || cleanTemporaryZonesIsExecuting || !canClean}
                             color="inherit"
                             size="medium"
                             variant="extended"
@@ -195,7 +260,22 @@ const ZoneActions = (
                 }
                 <Grid item>
                     <ActionButton
-                        disabled={zones.length === zoneProperties.zoneCount.max || cleanTemporaryZonesIsExecuting}
+                        disabled={cleanTemporaryZonesIsExecuting || !canClean}
+                        color="inherit"
+                        size="medium"
+                        variant="extended"
+                        onClick={onZoneOrderModeToggle}
+                        title="Zone order mode"
+                        style={{
+                            textTransform: "initial"
+                        }}
+                    >
+                        {zoneOrderMode === "manual" ? "Manual" : "Auto"}
+                    </ActionButton>
+                </Grid>
+                <Grid item>
+                    <ActionButton
+                        disabled={zones.length === zoneProperties.zoneCount.max || cleanTemporaryZonesIsExecuting || !canClean}
                         color="inherit"
                         size="medium"
                         variant="extended"

--- a/frontend/src/map/structures/client_structures/ZoneClientStructure.ts
+++ b/frontend/src/map/structures/client_structures/ZoneClientStructure.ts
@@ -1,6 +1,7 @@
 import ClientStructure from "./ClientStructure";
 import deleteButtonIconSVG from "../icons/delete_zone.svg";
 import scaleButtonIconSVG from "../icons/scale_zone.svg";
+import {getEffectiveCmPerMapUnit} from "../../MapMeasurementConfig";
 import {StructureInterceptionHandlerResult} from "../Structure";
 import {Canvas2DContextTrackingWrapper} from "../../utils/Canvas2DContextTrackingWrapper";
 import {PointCoordinates} from "../../utils/types";
@@ -45,9 +46,10 @@ class ZoneClientStructure extends ClientStructure {
         const p0 = new DOMPoint(this.x0, this.y0).matrixTransform(transformationMatrixToScreenSpace);
         const p1 = new DOMPoint(this.x1, this.y1).matrixTransform(transformationMatrixToScreenSpace);
 
+        const cmPerMapUnit = getEffectiveCmPerMapUnit(pixelSize);
         const dimensions = {
-            x: ((Math.round(this.x1) - Math.round(this.x0)) * pixelSize) / 100,
-            y: ((Math.round(this.y1) - Math.round(this.y0)) * pixelSize) / 100
+            x: ((Math.round(this.x1) - Math.round(this.x0)) * cmPerMapUnit) / 100,
+            y: ((Math.round(this.y1) - Math.round(this.y0)) * cmPerMapUnit) / 100
         };
         const label = dimensions.x.toFixed(2) + " x " + dimensions.y.toFixed(2) + "m";
 

--- a/frontend/src/map/structures/client_structures/ZoneClientStructure.ts
+++ b/frontend/src/map/structures/client_structures/ZoneClientStructure.ts
@@ -20,6 +20,7 @@ class ZoneClientStructure extends ClientStructure {
 
     public x1: number;
     public y1: number;
+    public orderLabel: string | undefined;
 
     constructor(
         x0: number, y0: number,
@@ -74,19 +75,48 @@ class ZoneClientStructure extends ClientStructure {
 
         ctxWrapper.restore();
 
-        ctxWrapper.save();
-        ctx.textAlign = "start";
-        ctx.fillStyle = "rgba(255, 255, 255, 1)";
-        ctx.strokeStyle = "rgba(18, 18, 18, 1)";
-        ctx.font = `${considerHiDPI(6) * scaleFactor}px sans-serif`;
+        if (this.active) {
+            ctxWrapper.save();
+            ctx.textAlign = "start";
+            ctx.fillStyle = "rgba(255, 255, 255, 1)";
+            ctx.strokeStyle = "rgba(18, 18, 18, 1)";
+            ctx.font = `${considerHiDPI(6) * scaleFactor}px sans-serif`;
 
-        ctx.lineWidth = considerHiDPI(3);
-        ctx.strokeText(label, p0.x, p0.y - considerHiDPI(8));
+            ctx.lineWidth = considerHiDPI(3);
+            ctx.strokeText(label, p0.x, p0.y - considerHiDPI(8));
 
-        ctx.lineWidth = considerHiDPI(1);
-        ctx.fillText(label, p0.x, p0.y - considerHiDPI(8));
+            ctx.lineWidth = considerHiDPI(1);
+            ctx.fillText(label, p0.x, p0.y - considerHiDPI(8));
 
-        ctxWrapper.restore();
+            ctxWrapper.restore();
+        }
+
+        if (this.orderLabel) {
+            const center = {
+                x: p0.x + ((p1.x - p0.x) / 2),
+                y: p0.y + ((p1.y - p0.y) / 2)
+            };
+            const orderFontSize = Math.max(
+                considerHiDPI(18),
+                Math.min(considerHiDPI(36), considerHiDPI(7) * scaleFactor)
+            );
+
+            ctxWrapper.save();
+
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.fillStyle = "rgba(255, 255, 255, 1)";
+            ctx.strokeStyle = "rgba(18, 18, 18, 1)";
+            ctx.font = `bold ${orderFontSize}px sans-serif`;
+
+            ctx.lineWidth = considerHiDPI(4);
+            ctx.strokeText(this.orderLabel, center.x, center.y);
+
+            ctx.lineWidth = considerHiDPI(1);
+            ctx.fillText(this.orderLabel, center.x, center.y);
+
+            ctxWrapper.restore();
+        }
 
         if (this.active) {
             ctx.drawImage(

--- a/frontend/src/map/structures/map_structures/SegmentLabelMapStructure.ts
+++ b/frontend/src/map/structures/map_structures/SegmentLabelMapStructure.ts
@@ -154,7 +154,8 @@ class SegmentLabelMapStructure extends MapStructure {
             }
 
             if (scaleFactor >= considerHiDPI(11)) {
-                let metaString = (this.area / 10000).toPrecision(2) + " m²";
+                const displayedArea = (this.area / 10000) * getSegmentAreaMultiplier();
+                let metaString = displayedArea.toPrecision(2) + " m²";
                 metaString += ` (id=${this.id})`;
 
                 ctx.font = `${considerHiDPI(fontSize - 5)}px sans-serif`;


### PR DESCRIPTION
Adds UI labels for zone order and configurable map measurements.

Changes:

- Adds a "congatudo.zoneMeasurement" configuration section.
- Adds "cmPerMapUnit" to scale manual zone dimension labels.
- Adds "segmentAreaMultiplier" to optionally scale displayed room/segment area labels.
- Adds a read-only config endpoint for the frontend.
- Uses the configured values only for displayed labels.
- Shows compact measurement labels only when a zone is selected.
- Adds visible order numbers to selected zones.
- Adds a Manual/Auto zone order mode in the zone cleaning UI.
- Manual mode keeps the visible/manual zone order.
- Auto mode computes an approximate economical order, shows that order on the selected zones, and sends the zones array already ordered.

Payload behavior:

- The backend API is unchanged.
- The UI still sends the existing "zones" array and "iterations" field.
- This PR only changes the order of the "zones" array before sending it.
- Measurement labels do not affect robot payloads.

This does not change map coordinates, firmware behavior, "cleanAreas", "cleanRooms", segment cleaning, zone cleaning backend behavior, or Cecotec room custom ordering support.

Example local configuration:

{
  "congatudo": {
    "zoneMeasurement": {
      "cmPerMapUnit": 5.15,
      "segmentAreaMultiplier": 250
    }
  }
}

Defaults keep existing behavior unless the user configures a custom scale.